### PR TITLE
feat(ci-gitops): add new optional inputs

### DIFF
--- a/.github/workflows/ci-gitops.test.yaml
+++ b/.github/workflows/ci-gitops.test.yaml
@@ -14,5 +14,8 @@ jobs:
     uses: ./.github/workflows/ci-gitops.yaml
     with:
       working_dir: ./example-projects/kubernetes
+      ignore_dirs: .github,tests
+      kubeconform_ignore_filename_patterns: ".*gotk-.*,.*.sops.yaml"
+      kubeconform_skip_resources: "Secret"
       kubernetes_version: 1.27.4
       trivy_severity: "CRITICAL,HIGH"

--- a/.github/workflows/ci-gitops.yaml
+++ b/.github/workflows/ci-gitops.yaml
@@ -4,8 +4,23 @@ on:
     inputs:
       working_dir:
         type: string
-        description: "The working directory to use (e.g. ./prod)"
+        description: "A comma-separated list of directories to use (e.g. ./prod,./staging)"
         required: true
+      ignore_dirs:
+        type: string
+        description: "A comma-separated list of directory names to ignore"
+        required: false
+        default: ""
+      kubeconform_ignore_filename_patterns:
+        type: string
+        description: "A comma-separated list of regular expression specifying paths that kubeconform will ignore (e.g. .*gotk-.*,.*.sops.yaml)"
+        required: false
+        default: ""
+      kubeconform_skip_resources:
+        type: string
+        description: "A comma-separated list of kinds or GVKs kubeconform will ignore (e.g. Secret,ConfigMap)"
+        required: false
+        default: ""
       kubernetes_version:
         type: string
         description: "The Kubernetes version to use (e.g. 1.27.4)"
@@ -36,6 +51,9 @@ jobs:
       - name: "🕵️ Check ${{ inputs.working_dir }} manifests"
         run: |
           krmc check ${{ inputs.working_dir }} \
-            --verbose \
-            --kubernetes-version=${{ inputs.kubernetes_version }} \
-            --trivy-severity=${{ inputs.trivy_severity }}
+            --ignore-dirs="${{ inputs.ignore_dirs }}" \
+            --kubeconform-ignore-filename-patterns="${{ inputs.kubeconform_ignore_filename_patterns }}" \
+            --kubeconform-skip-resources="${{ inputs.kubeconform_skip_resources }}" \
+            --kubernetes-version="${{ inputs.kubernetes_version }}" \
+            --trivy-severity="${{ inputs.trivy_severity }}" \
+            --verbose

--- a/README.md
+++ b/README.md
@@ -205,15 +205,21 @@ jobs:
     uses: maandr/github-actions/.github/workflows/ci-gitops@<version>
     with:
       working_dir: ./example-projects/kubernetes
+      ignore_dirs: .github,tests
+      kubeconform_ignore_filename_patterns: ".*gotk-.*,.*.sops.yaml"
+      kubeconform_skip_resources: "Secret"
       kubernetes_version: 1.27.4
       trivy_severity: "CRITICAL,HIGH"
 ```
 
 #### Inputs
 
-| Name                 | Description                                                                 | Default                |
-|----------------------|-----------------------------------------------------------------------------|------------------------|
-| `working_dir`        | The working directory to use                                                | -                      |
-| `kubernetes_version` | The Kubernetes version to use (e.g. 1.27.4)                                 | -                      |
-| `trivy_severity`     | A comma-separated list of trivy severity levels to use (e.g. CRITICAL,HIGH) | `CRITICAL,HIGH,MEDIUM` |
-| `timeout_minutes`    | Duration the workflow is allowed to run                                     | `10`                   |
+| Name                                  | Description                                                                                                              | Default                |
+|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------|------------------------|
+| `working_dir`                         | A comma-separated list of directories to use (e.g. ./prod,./staging)                                                     | -                      |
+| `ignore_dirs`                         | A comma-separated list of directory names to ignore (e.g. flux-system)                                                   | none                   |
+| `kubeconform_ignore_filename_patterns` | A comma-separated list of regular expression specifying paths that kubeconform will ignore (e.g. .*gotk-.*,.*.sops.yaml) | none                   |
+| `kubeconform_skip_resources`          | A comma-separated list of kinds or GVKs kubeconform will ignore (e.g. Secret,ConfigMap)                                  | none                   |
+| `kubernetes_version`                  | The Kubernetes version to use (e.g. 1.27.4)                                                                              | -                      |
+| `trivy_severity`                      | A comma-separated list of trivy severity levels to use (e.g. CRITICAL,HIGH)                                              | `CRITICAL,HIGH,MEDIUM` |
+| `timeout_minutes`                     | Duration the workflow is allowed to run                                                                                  | `10`                   |


### PR DESCRIPTION
Add new inputs to `ci-gitops` workflow:
- `ignore_dirs` A comma-separated list of directories to ignore (default: none)
- `kubeconform_ignore_filename_patterns` A comma-separated list of regular expression specifying paths that kubeconform will ignore (default: none)
- `kubeconform_skip_resources` A comma-separated list of kinds or GVKs kubeconform will ignore (default: none)